### PR TITLE
Add material mkdoc install instruction for Linux/WSL

### DIFF
--- a/docs/how-to-guides/how-to-use-material-for-mkdocs.md
+++ b/docs/how-to-guides/how-to-use-material-for-mkdocs.md
@@ -7,7 +7,13 @@ Install [Material for MkDocs](../explanations/about-material-for-mkdocs.md) with
 === ":simple-linux: Linux"
 
 	```sh title="In a terminal, execute the following command(s)."
-	TODO
+	# Install Material for MkDocs and all its extensions
+	pip install --user \
+		cairosvg \
+		mkdocs-git-revision-date-localized-plugin \
+		mkdocs-glightbox \
+		mkdocs-material \
+		mkdocs-minify-plugin
 	```
 
 === ":simple-apple: macOS"


### PR DESCRIPTION
* cairo is usually already installed on popular distribution
* on more niche distro where it is not, the user knows how to handle it after seeing the message in terminal