### PR TITLE
70 tasks are not async on services

### DIFF
--- a/common-code/common_code/service/models.py
+++ b/common-code/common_code/service/models.py
@@ -39,5 +39,5 @@ class Service(BaseModel, metaclass=ABCMeta):
         return self.data_out_fields
 
     @abstractmethod
-    async def process(self, data):
+    def process(self, data):
         pass

--- a/common-code/common_code/tasks/service.py
+++ b/common-code/common_code/tasks/service.py
@@ -175,7 +175,12 @@ class TasksService:
         TasksService.current_task.task.status = TaskStatus.PROCESSING
         self.logger.info(f"Processing task {TasksService.current_task.task.id}")
         try:
-            TasksService.current_task_data_out = await self.my_service.process(TasksService.current_task_data_in)
+            loop = asyncio.get_running_loop()
+            # Non-blocking process
+            task_future = loop.run_in_executor(
+                None, self.my_service.process, TasksService.current_task_data_in
+            )
+            TasksService.current_task_data_out = await task_future
         except Exception as e:
             self.logger.error(f"Failed to process image: {str(e)}")
             TasksService.current_task.task.status = TaskStatus.ERROR

--- a/docs/tutorials/implement-service.md
+++ b/docs/tutorials/implement-service.md
@@ -331,7 +331,7 @@ class MyService(Service):
         )
 
     # TODO: 5. CHANGE THE PROCESS METHOD (CORE OF THE SERVICE) (5)!
-    async def process(self, data):
+    def process(self, data):
         # NOTE that the data is a dictionary with the keys being the field names set in the data_in_fields
         raw = data["image"].data
         input_type = data["image"].type

--- a/services/ae-ano-detection/model_serving/src/main.py
+++ b/services/ae-ano-detection/model_serving/src/main.py
@@ -51,7 +51,7 @@ class MyService(Service):
         )
         self.model = tf.keras.models.load_model("../model/ae_model.h5")
 
-    async def process(self, data):
+    def process(self, data):
         raw = str(data["text"].data)[2:-1]
         raw = raw.replace('\\t', ',').replace('\\n', '\n').replace('\\r', '\n')
         X_test = pd.read_csv(io.StringIO(raw), dtype={"value": np.float64})

--- a/services/average-shade/src/main.py
+++ b/services/average-shade/src/main.py
@@ -48,7 +48,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         # Get raw image data
         raw = data["image"].data
         img = cv2.imdecode(np.frombuffer(raw, np.uint8), cv2.IMREAD_COLOR)

--- a/services/digit-recognition/model_serving/src/main.py
+++ b/services/digit-recognition/model_serving/src/main.py
@@ -50,7 +50,7 @@ class MyService(Service):
 
         self.model = models.load_model("../mnist_model.h5")
 
-    async def process(self, data):
+    def process(self, data):
         # Get raw image data
         raw = data["image"].data
         # Convert to image object

--- a/services/face-analyzer/src/main.py
+++ b/services/face-analyzer/src/main.py
@@ -50,7 +50,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         # Get raw image data
         raw = data["image"].data
         buff = io.BytesIO(raw)

--- a/services/face-detection/src/main.py
+++ b/services/face-detection/src/main.py
@@ -50,7 +50,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         # Get raw image data
         raw = data["image"].data
         buff = io.BytesIO(raw)

--- a/services/image-analyzer/src/main.py
+++ b/services/image-analyzer/src/main.py
@@ -49,7 +49,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         raw = data["image"].data
         stream = io.BytesIO(raw)
         img = Image.open(stream)

--- a/services/image-blur/src/main.py
+++ b/services/image-blur/src/main.py
@@ -54,7 +54,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         raw = data["image"].data
         input_type = data["image"].type
         img = cv2.imdecode(np.frombuffer(raw, np.uint8), 1)

--- a/services/image-convert/src/main.py
+++ b/services/image-convert/src/main.py
@@ -48,7 +48,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         # TODO: modify to accept any image format and convert to any image format
         raw = data["image"].data
         input_type = data["image"].type

--- a/services/image-crop/src/main.py
+++ b/services/image-crop/src/main.py
@@ -50,7 +50,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         raw = data["image"].data
         input_type = data["image"].type
         img = cv2.imdecode(np.frombuffer(raw, np.uint8), 1)

--- a/services/image-greyscale/src/main.py
+++ b/services/image-greyscale/src/main.py
@@ -47,7 +47,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         raw = data["image"].data
         input_type = data["image"].type
         stream = io.BytesIO(raw)

--- a/services/image-resize/src/main.py
+++ b/services/image-resize/src/main.py
@@ -50,7 +50,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         raw = data["image"].data
         input_type = data["image"].type
         img = cv2.imdecode(np.frombuffer(raw, np.uint8), 1)

--- a/services/image-rotate/src/main.py
+++ b/services/image-rotate/src/main.py
@@ -50,7 +50,7 @@ class MyService(Service):
             ]
         )
 
-    async def process(self, data):
+    def process(self, data):
         # NOTE that the data is a dictionary with the keys being the field names set in the data_in_fields
         raw = data["image"].data
         input_type = data["image"].type


### PR DESCRIPTION
Convert the service implementation function to not be async which allows to call it in a new non-blocking thread. This fixes the issues where io/cpu intensive tasks would freeze the service api.

There three main solutions to this problem:
- Call the io/cpu intensive task in a new thread within the async process function
- Convert the whole Service run loop not be async
- Convert the process functions to not be async and call it in a new thread

I went with the third one as it was the one with less refactoring while maintaining the same `common-code` api.

You can find more information about the issue here: https://stackoverflow.com/questions/71516140/fastapi-runs-api-calls-in-serial-instead-of-parallel-fashion/71517830#71517830