### PR TITLE
fix: backend : replace mc config host with mc alias set

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -77,7 +77,11 @@ services:
       - MINIO_ROOT_PASSWORD=minio123
     entrypoint: >
       sh -c "
-        mc config host rm local;
-        mc config host add --api s3v4 local http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
+        echo 'Waiting for MinIO...';
+        until mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD; do
+          echo 'Retrying...';
+          sleep 2;
+        done;
+        echo 'Connected. Creating bucket...';
         mc mb --ignore-existing local/engine;
       "


### PR DESCRIPTION
- The latest mc version no longer supports the mc config host command.

- Updated the entrypoint script to use mc alias set with a retry loop until MinIO is available before creating the bucket.