### PR TITLE
backend : fix : service wake-up route path

### DIFF
--- a/backend/src/services/controller.py
+++ b/backend/src/services/controller.py
@@ -99,7 +99,7 @@ def get_one_by_slug(
 
 
 @router.post(
-    "/services/slug{service_slug}/wake-up",
+    "/services/slug/{service_slug}/wake-up",
     summary="Wake up a service",
     responses={
         404: {"detail": "Service Not Found"},


### PR DESCRIPTION
Add the missing slash in the wake-up endpoint path to fix routing: "/services/slug/{service_slug}/wake-up" (was "/services/slug{service_slug}/wake-up").