### PR TITLE
fix : handle timezone for service heartbeat check

### DIFF
--- a/backend/src/services/service.py
+++ b/backend/src/services/service.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from inspect import Parameter, Signature
 from sqlalchemy.exc import IntegrityError
 from common_code.common.models import ExecutionUnitTag


### PR DESCRIPTION
Make heartbeat time comparisons timezone-aware to avoid naive/aware datetime errors and incorrect results.